### PR TITLE
ci(pages): revert job permissions contents:write -> contents:read

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,6 @@ jobs:
   publish-pages:
     uses: Knuckles-Team/pipelines/.github/workflows/pages_pipeline.yml@main
     permissions:
-      contents: write
+      contents: read
       pages: write
       id-token: write


### PR DESCRIPTION
Reverts the caller-side contents:write grant added by the earlier pages_pipeline permission-contract sweep. Root cause was fixed at the callee (Knuckles-Team/pipelines PR #3, merge ea76970: pages_pipeline.yml now declares contents:read since no step writes repo contents). This caller no longer needs contents:write. Part of lane w6-repo-hygiene; canary verified green on caddy-mcp (run 31189249208).